### PR TITLE
Add utility playbook to download artefacts for all roles

### DIFF
--- a/molecule/download-artifacts/converge.yml
+++ b/molecule/download-artifacts/converge.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+    - import_playbook: vexxhost.containers.download_artifacts
+      vars:
+        target: localhost

--- a/molecule/download-artifacts/molecule.yml
+++ b/molecule/download-artifacts/molecule.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    environment:
+      container: docker
+    security_opts:
+      - apparmor=unconfined
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /lib/modules:/lib/modules:ro
+provisioner:
+  name: ansible
+  config_options:
+    connection:
+      pipelining: true
+verifier:
+  name: ansible

--- a/molecule/download-artifacts/prepare.yml
+++ b/molecule/download-artifacts/prepare.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Prepare
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Wait for systemd to complete initialization
+      ansible.builtin.command: systemctl is-system-running
+      register: systemctl_status
+      until: >
+        'running' in systemctl_status.stdout or
+        'degraded' in systemctl_status.stdout
+      retries: 30
+      delay: 5
+      changed_when: false
+      failed_when: systemctl_status.rc > 1
+  tasks:
+    - name: Run APT update
+      ansible.builtin.apt:
+        update_cache: yes
+      when: ansible_facts['pkg_mgr'] == "apt"

--- a/molecule/download-artifacts/verify.yml
+++ b/molecule/download-artifacts/verify.yml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 VEXXHOST, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Verify
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Populate package facts
+      ansible.builtin.package_facts:
+
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+  tasks:
+    - name: Assert that the NGINX package is not installed
+      ansible.builtin.assert:
+        that:
+          - '"nginx" not in ansible_facts.packages'
+
+    - name: Assert that the NGINX service is still up
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.services["nginx.service"].state == "running"
+          - ansible_facts.services["nginx.service"].status == "enabled"

--- a/playbooks/download_artifacts.yml
+++ b/playbooks/download_artifacts.yml
@@ -1,0 +1,50 @@
+- hosts: "{{ target | default('all') }}"
+  gather_facts: false
+  vars:
+    role_location: "{{ playbook_dir }}/../roles"
+
+    #some role defaults use vars only defined in the download_artifact role
+    _download_artifact_goarch_groups:
+      x86_64: amd64
+      aarch64: arm64
+      armv7l: arm
+
+    download_artifact_goarch: >-
+      {%- if ansible_facts['architecture'] in _download_artifact_goarch_groups -%}
+      {{ _download_artifact_goarch_groups[ansible_facts['architecture']] }}
+      {%- else -%}
+      {{ ansible_facts['architecture'] }}
+      {%- endif -%}
+
+  tasks:
+    - setup:
+        gather_subset: min
+
+    # find all subdirectories in the role location
+    - ansible.builtin.find:
+        file_type: directory
+        paths: "{{ role_location }}"
+        recurse: true
+      register: role_paths
+
+    # select only defaults/ directories and load vars
+    - include_vars:
+        dir: "{{ item.path }}"
+      with_items: "{{ role_paths.files | selectattr('path', 'search', 'defaults') }}"
+
+    # download all artifacts defined by *_download_url
+    - include_role:
+        name: vexxhost.containers.download_artifact
+      vars:
+        _archive_checksum: "{{ lookup('vars', item ~ '_archive_checksum', default='') }}"
+        _checksum: "{{ lookup('vars', item ~ '_binary_checksum', default=_archive_checksum) }}"
+        _binary_version: "{{ lookup('vars', item ~ '_version', default='') }}"
+        _download_dest: "{{ lookup('vars', item ~ '_download_dest') }}"
+        _binary_dest: "{{ download_artifact_work_directory ~ '/' ~ item ~ '-' ~ _binary_version ~ '-' ~ download_artifact_goarch }}"
+        download_artifact_url: "{{ lookup('vars', item ~ '_download_url') }}"
+        download_artifact_dest: "{{ _download_dest | regex_search('/usr/') | ternary(_binary_dest, _download_dest) }}"
+        download_artifact_checksum: "sha256:{{ _checksum }}"
+        download_artifact_owner: root
+        download_artifact_mode: "0755"
+        download_artifact_unarchive: false
+      with_items: "{{ query('varnames', '_download_url$') | map('replace', '_download_url', '') }}"


### PR DESCRIPTION
Usage: ansible-playbook vexxhost.containers.download_artifacts -e target=localhost

This playbook uses the existing download_artifact role and downloads the artefacts required for all roles.