### PR TITLE
Add override for containerd snapshotter

### DIFF
--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -61,3 +61,7 @@ containerd_limit_core: "infinity"
 #                 ulimit nofile to a more reasonable value.
 containerd_limit_open_file_num: "{{ '1048576' if ansible_facts['os_family'] == 'RedHat' else 'infinity' }}"
 containerd_limit_mem_lock: "infinity"
+
+# NOTE(jrosser): If you need to override the default containerd snapshotter, for example
+# when the underlying filesystem does not support overlayfs, set it here
+containerd_snapshotter: ""

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -21,3 +21,5 @@ oom_score = {{ containerd_oom_score }}
       [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ registry }}".tls]
         insecure_skip_verify = true
       {% endfor %}
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    {% if containerd_snapshotter | length %}snapshotter = "{{ containerd_snapshotter }}"{% endif %}


### PR DESCRIPTION
Some underlying storage types do not support the default snapshotter so we add a variable to allow a different snapshotter type to be selected.