### PR TITLE
[ATMOSPHERE-354] runc: Update to version 1.1.13

### DIFF
--- a/roles/runc/defaults/main.yml
+++ b/roles/runc/defaults/main.yml
@@ -12,12 +12,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-runc_version: v1.1.10
+runc_version: v1.1.13
 runc_checksums:
   amd64:
-    v1.1.10: 81f73a59be3d122ab484d7dfe9ddc81030f595cc59968f61c113a9a38a2c113a
+    v1.1.13: bcfc299c1ab255e9d045ffaf2e324c0abaf58f599831a7c2c4a80b33f795de94
   arm64:
-    v1.1.10: 4830afd426bdeacbdf9cb8729524aa2ed51790b8c4b28786995925593708f1c8
+    v1.1.13: 4b93701752f5338ed51592b38e039aef8c1a59856d1225df21eba84c2830743c
 runc_download_url: "https://github.com/opencontainers/runc/releases/download/{{ runc_version }}/runc.{{ download_artifact_goarch }}"
 runc_download_dest: /usr/bin/runc
 runc_binary_checksum: "{{ runc_checksums[download_artifact_goarch][runc_version] }}"


### PR DESCRIPTION
Release notes:
* https://github.com/opencontainers/runc/releases/tag/v1.1.11
* https://github.com/opencontainers/runc/releases/tag/v1.1.12
* https://github.com/opencontainers/runc/releases/tag/v1.1.13