### PR TITLE
chore: bump nerdctl to version 2.1.3

### DIFF
--- a/roles/nerdctl/defaults/main.yml
+++ b/roles/nerdctl/defaults/main.yml
@@ -12,12 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-nerdctl_version: 1.7.4
+nerdctl_version: 2.1.3
 nerdctl_checksums:
   amd64:
     1.7.4: 71aee9d987b7fad0ff2ade50b038ad7e2356324edc02c54045960a3521b3e6a7
+    2.1.3: 227390fb16c20d6ab3a7588e5ce72202df1bec7960a2a091599ce3c1bf3fd1d8
   arm64:
     1.7.4: d8df47708ca57b9cd7f498055126ba7dcfc811d9ba43aae1830c93a09e70e22d
+    2.1.3: 62e34ce6156c942368968c0d88c731cb2f3b341785d584e56a2c175916d5f88d
 
 nerdctl_download_url: "https://github.com/containerd/nerdctl/releases/download/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-{{ ansible_facts['system'] | lower }}-{{ download_artifact_goarch }}.tar.gz" # noqa: yaml[line-length]
 nerdctl_download_dest: "{{ download_artifact_work_directory }}/nerdctl-{{ nerdctl_version }}-{{ ansible_facts['system'] | lower }}-{{ download_artifact_goarch }}.tar.gz" # noqa: yaml[line-length]


### PR DESCRIPTION
bump nerdctl to version 2.1.3 this to fix "in namespace "k8s.io": not found" error.