### PR TITLE
feat: switch to py311 and upgrade ansible.posix to 1.6.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: Ansible collection for deploying container runtimes
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.posix: '>=1.3.0'
+  ansible.posix: '>=1.6.0'
   community.general: '>=4.5.0'
 tags:
   - application


### PR DESCRIPTION
- I mentioned about py311 switch again in this commit message to add it in the CHANGELOG by release-please auto.
- k8s collection starts using 1.6< posix.