### PR TITLE
fix(containerd,docker): add retry logic to package installation tasks

### DIFF
--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -22,6 +22,10 @@
       ansible.builtin.package:
         state: present
         name: container-selinux
+      register: _install_selinux
+      retries: 5
+      delay: 10
+      until: _install_selinux is not failed
 
     - name: Set SELinux to permissive at runtime
       ansible.builtin.command: setenforce 0
@@ -38,6 +42,10 @@
     name:
       - apparmor
       - apparmor-utils
+  register: _install_apparmor
+  retries: 5
+  delay: 10
+  until: _install_apparmor is not failed
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Create systemd service file for containerd

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -18,6 +18,10 @@
     name:
       - apparmor
       - apparmor-utils
+  register: _install_apparmor
+  retries: 5
+  delay: 10
+  until: _install_apparmor is not failed
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure group "docker" exists


### PR DESCRIPTION
The containerd and docker roles' package installation tasks (`Install AppArmor packages`, `Install SELinux packages`) lack retry logic. When these roles run concurrently with other components that hold the dpkg lock, the package tasks fail immediately with `rc:100` instead of retrying.

This adds `retries: 5` and `delay: 10` to all package tasks in both the `containerd` and `docker` roles, matching the pattern used by other Ansible roles.

**Context:** vexxhost/atmosphere#3834 introduces a parallel deployment orchestrator where multiple components run concurrently in Wave 0. The ceph component calls `vexxhost.containers.containerd` which installs AppArmor packages. When other components (multipathd, iscsi) run apt concurrently, the AppArmor install fails with dpkg lock contention (`rc:100`).

**Related:** vexxhost/ansible-collection-kubernetes#262 (same fix for kubelet role)