### PR TITLE
fix(containerd): normalize sandbox image digest references

### DIFF
--- a/plugins/filter/docker_image.py
+++ b/plugins/filter/docker_image.py
@@ -43,7 +43,7 @@ options:
   part:
     type: string
     default: 'ref'
-    options: [name, ref, tag, domain, path]
+    options: [name, ref, digest_ref, tag, digest, domain, path, prefix]
     required: true
     description:
       - Part of the Docker image reference to return
@@ -93,6 +93,10 @@ def docker_image(value, part="ref", registry=None):
             return ref.repository["path"]
         if part == "digest":
             return ref["digest"]
+        if part == "digest_ref":
+            if ref["digest"]:
+                return "{}@{}".format(ref["name"], ref["digest"])
+            return ref.string()
         if part == "prefix":
             path_parts = ref.repository["path"].split("/")[:-1]
             parts = [ref.repository["domain"]] + path_parts

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -8,7 +8,7 @@ oom_score = {{ containerd_oom_score }}
 
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
-    sandbox_image = "{{ containerd_pause_image | vexxhost.containers.docker_image('ref') }}"
+    sandbox_image = "{{ containerd_pause_image | vexxhost.containers.docker_image('digest_ref') }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
 {% if ansible_facts['selinux'].status == 'enabled' %}
     enable_selinux = true

--- a/tests/unit/plugins/filter/test_docker_image.py
+++ b/tests/unit/plugins/filter/test_docker_image.py
@@ -44,6 +44,20 @@ def test_docker_image_ref(test_input, expected):
 @pytest.mark.parametrize(
     "test_input,expected",
     [
+        ("quay.io/vexxhost/glance:zed", "quay.io/vexxhost/glance:zed"),
+        (
+            "k8s.gcr.io/ingress-nginx/controller:v1.1.1@sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de",  # noqa E501
+            "k8s.gcr.io/ingress-nginx/controller@sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de",  # noqa E501
+        ),
+    ],
+)
+def test_docker_image_digest_ref(test_input, expected):
+    assert docker_image(test_input, "digest_ref") == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
         ("quay.io/vexxhost/glance:zed", "quay.io/vexxhost/glance"),
         (
             "us-docker.pkg.dev/vexxhost-infra/openstack/heat:wallaby",


### PR DESCRIPTION
## Summary
- add a digest_ref docker image filter mode that renders digest-backed images as name@digest
- use digest_ref for containerd sandbox_image so tag@digest pause image values do not break pod sandbox creation
- cover tag-only and tag-plus-digest inputs in docker_image unit tests

## Test
- PYTHONPATH=/tmp uv run pytest tests/unit/plugins/filter/test_docker_image.py