### PR TITLE
feat: upgrade docker to the latest 29.7.2 version

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -41,7 +41,7 @@
     parent: ansible-collection-containers-molecule
     abstract: true
     vars:
-      docker_version: 24.0.9
+      docker_version: 29.7.2
       molecule_scenario: docker
 
 - job:

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -69,6 +69,38 @@
     nodeset: ubuntu-noble
 
 - job:
+    name: ansible-collection-containers-molecule-docker-upgrade
+    parent: ansible-collection-containers-molecule-docker
+    abstract: true
+    vars:
+      molecule_scenario: docker-upgrade
+
+- job:
+    name: ansible-collection-containers-molecule-docker-upgrade-debian-trixie
+    parent: ansible-collection-containers-molecule-docker-upgrade
+    nodeset: debian-trixie
+
+- job:
+    name: ansible-collection-containers-molecule-docker-upgrade-rockylinux-9
+    parent: ansible-collection-containers-molecule-docker-upgrade
+    nodeset: rockylinux-9
+
+- job:
+    name: ansible-collection-containers-molecule-docker-upgrade-ubuntu-focal
+    parent: ansible-collection-containers-molecule-docker-upgrade
+    nodeset: ubuntu-focal
+
+- job:
+    name: ansible-collection-containers-molecule-docker-upgrade-ubuntu-jammy
+    parent: ansible-collection-containers-molecule-docker-upgrade
+    nodeset: ubuntu-jammy
+
+- job:
+    name: ansible-collection-containers-molecule-docker-upgrade-ubuntu-noble
+    parent: ansible-collection-containers-molecule-docker-upgrade
+    nodeset: ubuntu-noble
+
+- job:
     name: ansible-collection-containers-molecule-download-binaries
     parent: ansible-collection-containers-molecule
     vars:
@@ -147,6 +179,11 @@
         - ansible-collection-containers-molecule-docker-ubuntu-focal
         - ansible-collection-containers-molecule-docker-ubuntu-jammy
         - ansible-collection-containers-molecule-docker-ubuntu-noble
+        - ansible-collection-containers-molecule-docker-upgrade-debian-trixie
+        - ansible-collection-containers-molecule-docker-upgrade-rockylinux-9
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-focal
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-jammy
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-noble
         - ansible-collection-containers-molecule-download-binaries
         - ansible-collection-containers-molecule-forget-package-debian-trixie
         - ansible-collection-containers-molecule-forget-package-ubuntu-focal
@@ -171,6 +208,11 @@
         - ansible-collection-containers-molecule-docker-ubuntu-focal
         - ansible-collection-containers-molecule-docker-ubuntu-jammy
         - ansible-collection-containers-molecule-docker-ubuntu-noble
+        - ansible-collection-containers-molecule-docker-upgrade-debian-trixie
+        - ansible-collection-containers-molecule-docker-upgrade-rockylinux-9
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-focal
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-jammy
+        - ansible-collection-containers-molecule-docker-upgrade-ubuntu-noble
         - ansible-collection-containers-molecule-download-binaries
         - ansible-collection-containers-molecule-forget-package-debian-trixie
         - ansible-collection-containers-molecule-forget-package-ubuntu-focal

--- a/extensions/molecule/docker-upgrade/converge.yml
+++ b/extensions/molecule/docker-upgrade/converge.yml
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Converge Docker upgrade
+  hosts: all
+  become: true
+  roles:
+    - vexxhost.containers.docker

--- a/extensions/molecule/docker-upgrade/molecule.yml
+++ b/extensions/molecule/docker-upgrade/molecule.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+ansible:
+  cfg:
+    defaults:
+      callbacks_enabled: ansible.posix.profile_tasks
+      inject_facts_as_vars: false
+    connection:
+      pipelining: true
+  executor:
+    backend: ansible-playbook
+    args:
+      ansible_playbook:
+        - --inventory=${MOLECULE_PROJECT_DIRECTORY}/inventory.yaml

--- a/extensions/molecule/docker-upgrade/prepare.yml
+++ b/extensions/molecule/docker-upgrade/prepare.yml
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Prepare Docker upgrade
+  hosts: all
+  become: true
+  vars:
+    docker_upgrade_from_version: 24.0.9
+    docker_upgrade_containers:
+      - molecule-upgrade-busybox
+      - molecule-upgrade-nginx
+    docker_upgrade_binaries:
+      - docker
+      - docker-init
+      - dockerd
+      - docker-proxy
+
+  pre_tasks:
+    - name: Update "apt" cache
+      ansible.builtin.apt:
+        update_cache: true
+      when:
+        - ansible_facts['os_family'] | lower == 'debian'
+
+  roles:
+    - role: vexxhost.containers.docker
+      docker_version: "{{ docker_upgrade_from_version }}"
+      docker_config:
+        oom-score-adjust: 0
+
+  post_tasks:
+    - name: Stop Docker before establishing legacy binary layout
+      ansible.builtin.service:
+        name: docker
+        state: stopped
+
+    - name: Remove versioned Docker binary links
+      ansible.builtin.file:
+        path: "/usr/bin/{{ item }}"
+        state: absent
+      loop: "{{ docker_upgrade_binaries }}"
+
+    - name: Install legacy Docker binaries directly into /usr/bin
+      ansible.builtin.copy:
+        src: "/var/lib/downloads/docker-{{ docker_upgrade_from_version }}/{{ item }}"
+        dest: "/usr/bin/{{ item }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+      loop: "{{ docker_upgrade_binaries }}"
+
+    - name: Start Docker from legacy binary layout
+      ansible.builtin.service:
+        name: docker
+        state: started
+
+    - name: Create HTTP workload configuration
+      ansible.builtin.copy:
+        dest: /var/lib/docker-upgrade-nginx.conf
+        mode: "0644"
+        content: |
+          server {
+              listen 18080;
+              location / {
+                  return 200 "docker-upgrade-ok\n";
+              }
+          }
+
+    - name: Pull workload images
+      ansible.builtin.command:
+        argv:
+          - docker
+          - image
+          - pull
+          - "{{ item }}"
+      loop:
+        - docker.io/library/busybox:1.36.1
+        - docker.io/library/nginx:1.27.5-alpine
+      changed_when: false
+
+    - name: Start counter workload container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - run
+          - --detach
+          - --name
+          - molecule-upgrade-busybox
+          - docker.io/library/busybox:1.36.1
+          - sh
+          - -c
+          - while true; do date +%s >> /tmp/ticks; sleep 1; done
+      changed_when: true
+
+    - name: Start HTTP workload container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - run
+          - --detach
+          - --name
+          - molecule-upgrade-nginx
+          - --network
+          - host
+          - --mount
+          - type=bind,source=/var/lib/docker-upgrade-nginx.conf,target=/etc/nginx/conf.d/default.conf,readonly
+          - docker.io/library/nginx:1.27.5-alpine
+      changed_when: true
+
+    - name: Wait for the HTTP workload
+      ansible.builtin.uri:
+        url: http://127.0.0.1:18080/
+        return_content: true
+      register: _docker_upgrade_http_before
+      retries: 30
+      delay: 1
+      until: _docker_upgrade_http_before.status == 200
+
+    - name: Read Docker service PID
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - --property=MainPID
+          - --value
+          - docker.service
+      register: _docker_upgrade_dockerd_pid_before
+      changed_when: false
+
+    - name: Read Docker service invocation ID
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - --property=InvocationID
+          - --value
+          - docker.service
+      register: _docker_upgrade_invocation_id_before
+      changed_when: false
+
+    - name: Read running Docker server version
+      ansible.builtin.command:
+        cmd: >-
+          docker version --format
+          '{% raw %}{{ .Server.Version }}{% endraw %}'
+      register: _docker_upgrade_server_version_before
+      changed_when: false
+
+    - name: Read running Docker live-restore state
+      ansible.builtin.command:
+        cmd: >-
+          docker info --format
+          '{% raw %}{{ .LiveRestoreEnabled }}{% endraw %}'
+      register: _docker_upgrade_live_restore_before
+      changed_when: false
+
+    - name: Read legacy Docker daemon configuration
+      ansible.builtin.slurp:
+        src: /etc/docker/daemon.json
+      register: _docker_upgrade_daemon_config_before_file
+
+    - name: Decode legacy Docker daemon configuration
+      ansible.builtin.set_fact:
+        _docker_upgrade_daemon_config_before: >-
+          {{
+            _docker_upgrade_daemon_config_before_file.content |
+            b64decode |
+            from_json
+          }}
+
+    - name: Assert legacy Docker state matches the fleet
+      ansible.builtin.assert:
+        that:
+          - _docker_upgrade_server_version_before.stdout == docker_upgrade_from_version
+          - _docker_upgrade_live_restore_before.stdout | bool
+          - _docker_upgrade_daemon_config_before['live-restore']
+          - _docker_upgrade_daemon_config_before['oom-score-adjust'] == 0
+
+    - name: Read running Docker daemon executable inode
+      ansible.builtin.command:
+        argv:
+          - stat
+          - --dereference
+          - --format=%i
+          - "/proc/{{ _docker_upgrade_dockerd_pid_before.stdout }}/exe"
+      register: _docker_upgrade_dockerd_executable_inode_before
+      changed_when: false
+
+    - name: Inspect Docker socket
+      ansible.builtin.stat:
+        path: /run/docker.sock
+        follow: true
+      register: _docker_upgrade_socket_before
+
+    - name: Inspect workload containers
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - "{{ item }}"
+      loop: "{{ docker_upgrade_containers }}"
+      register: _docker_upgrade_inspects_before
+      changed_when: false
+
+    - name: Read counter workload progress
+      ansible.builtin.command:
+        argv:
+          - docker
+          - exec
+          - molecule-upgrade-busybox
+          - sh
+          - -c
+          - wc -l < /tmp/ticks
+      register: _docker_upgrade_counter_before
+      changed_when: false
+
+    - name: Build workload state snapshot
+      ansible.builtin.set_fact:
+        _docker_upgrade_containers_before: >-
+          {{
+            _docker_upgrade_containers_before | default({}) |
+            combine({
+              item.item: {
+                'id': _container.Id,
+                'pid': _container.State.Pid,
+                'started_at': _container.State.StartedAt,
+                'restart_count': _container.RestartCount
+              }
+            })
+          }}
+      vars:
+        _container: "{{ (item.stdout | from_json)[0] }}"
+      loop: "{{ _docker_upgrade_inspects_before.results }}"
+
+    - name: Save pre-upgrade state
+      ansible.builtin.copy:
+        dest: /var/lib/docker-upgrade-state.json
+        mode: "0600"
+        content: >-
+          {{
+            {
+              'dockerd_pid': _docker_upgrade_dockerd_pid_before.stdout | int,
+              'invocation_id': _docker_upgrade_invocation_id_before.stdout,
+              'server_version': _docker_upgrade_server_version_before.stdout,
+              'dockerd_executable_inode': _docker_upgrade_dockerd_executable_inode_before.stdout | int,
+              'socket_inode': _docker_upgrade_socket_before.stat.inode,
+              'counter': _docker_upgrade_counter_before.stdout | int,
+              'containers': _docker_upgrade_containers_before
+            } | to_nice_json
+          }}

--- a/extensions/molecule/docker-upgrade/verify.yml
+++ b/extensions/molecule/docker-upgrade/verify.yml
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Verify staged Docker upgrade
+  hosts: all
+  become: true
+  vars:
+    docker_upgrade_from_version: 24.0.9
+    docker_upgrade_binary_install_dir: "/var/lib/downloads/docker-{{ docker_version }}"
+    docker_upgrade_binaries:
+      - docker
+      - docker-init
+      - dockerd
+      - docker-proxy
+
+  tasks:
+    - name: Read pre-upgrade state
+      ansible.builtin.slurp:
+        src: /var/lib/docker-upgrade-state.json
+      register: _docker_upgrade_state_file
+
+    - name: Decode pre-upgrade state
+      ansible.builtin.set_fact:
+        _docker_upgrade_before: >-
+          {{ _docker_upgrade_state_file.content | b64decode | from_json }}
+
+    - name: Read current Docker service PID
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - --property=MainPID
+          - --value
+          - docker.service
+      register: _docker_upgrade_dockerd_pid_after
+      changed_when: false
+
+    - name: Read current Docker service invocation ID
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - show
+          - --property=InvocationID
+          - --value
+          - docker.service
+      register: _docker_upgrade_invocation_id_after
+      changed_when: false
+
+    - name: Read current Docker server version
+      ansible.builtin.command:
+        cmd: >-
+          docker version --format
+          '{% raw %}{{ .Server.Version }}{% endraw %}'
+      register: _docker_upgrade_server_version_after
+      changed_when: false
+
+    - name: Read installed Docker daemon version
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/dockerd
+          - --version
+      register: _docker_upgrade_installed_version
+      changed_when: false
+
+    - name: Inspect installed Docker binary links
+      ansible.builtin.stat:
+        path: "/usr/bin/{{ item }}"
+        follow: false
+      loop: "{{ docker_upgrade_binaries }}"
+      register: _docker_upgrade_binary_links
+
+    - name: Read future Docker daemon configuration
+      ansible.builtin.slurp:
+        src: /etc/docker/daemon.json
+      register: _docker_upgrade_daemon_config_file
+
+    - name: Decode future Docker daemon configuration
+      ansible.builtin.set_fact:
+        _docker_upgrade_daemon_config: >-
+          {{ _docker_upgrade_daemon_config_file.content | b64decode | from_json }}
+
+    - name: Resolve running Docker daemon executable
+      ansible.builtin.command:
+        argv:
+          - readlink
+          - "/proc/{{ _docker_upgrade_before.dockerd_pid }}/exe"
+      register: _docker_upgrade_running_dockerd
+      changed_when: false
+
+    - name: Read running Docker daemon executable inode
+      ansible.builtin.command:
+        argv:
+          - stat
+          - --dereference
+          - --format=%i
+          - "/proc/{{ _docker_upgrade_before.dockerd_pid }}/exe"
+      register: _docker_upgrade_dockerd_executable_inode_after
+      changed_when: false
+
+    - name: Inspect current Docker socket
+      ansible.builtin.stat:
+        path: /run/docker.sock
+        follow: true
+      register: _docker_upgrade_socket_after
+
+    - name: Inspect workload containers after upgrade
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - "{{ item.key }}"
+      loop: "{{ _docker_upgrade_before.containers | dict2items }}"
+      register: _docker_upgrade_inspects_after
+      changed_when: false
+
+    - name: Build current workload state
+      ansible.builtin.set_fact:
+        _docker_upgrade_containers_after: >-
+          {{
+            _docker_upgrade_containers_after | default({}) |
+            combine({
+              item.item.key: {
+                'id': _container.Id,
+                'pid': _container.State.Pid,
+                'running': _container.State.Running,
+                'started_at': _container.State.StartedAt,
+                'restart_count': _container.RestartCount
+              }
+            })
+          }}
+      vars:
+        _container: "{{ (item.stdout | from_json)[0] }}"
+      loop: "{{ _docker_upgrade_inspects_after.results }}"
+
+    - name: Assert Docker daemon was not restarted
+      ansible.builtin.assert:
+        that:
+          - _docker_upgrade_dockerd_pid_after.stdout | int == _docker_upgrade_before.dockerd_pid
+          - _docker_upgrade_invocation_id_after.stdout == _docker_upgrade_before.invocation_id
+          - _docker_upgrade_server_version_after.stdout == docker_upgrade_from_version
+          - _docker_upgrade_server_version_after.stdout == _docker_upgrade_before.server_version
+          - _docker_upgrade_running_dockerd.stdout.startswith('/usr/bin/dockerd')
+          - _docker_upgrade_dockerd_executable_inode_after.stdout | int == _docker_upgrade_before.dockerd_executable_inode
+
+    - name: Assert new Docker daemon is installed for future activation
+      ansible.builtin.assert:
+        that:
+          - docker_version in _docker_upgrade_installed_version.stdout
+          - _docker_upgrade_socket_after.stat.inode == _docker_upgrade_before.socket_inode
+          - _docker_upgrade_daemon_config['live-restore']
+          - "'oom-score-adjust' not in _docker_upgrade_daemon_config"
+
+    - name: Assert Docker binaries point to the staged version
+      ansible.builtin.assert:
+        that:
+          - item.stat.islnk
+          - item.stat.lnk_source == docker_upgrade_binary_install_dir ~ '/' ~ item.item
+      loop: "{{ _docker_upgrade_binary_links.results }}"
+
+    - name: Assert workload containers were neither recreated nor restarted
+      ansible.builtin.assert:
+        that:
+          - _after.id == item.value.id
+          - _after.pid == item.value.pid
+          - _after.started_at == item.value.started_at
+          - _after.restart_count == item.value.restart_count
+          - _after.restart_count == 0
+          - _after.running
+      vars:
+        _after: "{{ _docker_upgrade_containers_after[item.key] }}"
+      loop: "{{ _docker_upgrade_before.containers | dict2items }}"
+
+    - name: Read counter workload progress after upgrade
+      ansible.builtin.command:
+        argv:
+          - docker
+          - exec
+          - molecule-upgrade-busybox
+          - sh
+          - -c
+          - wc -l < /tmp/ticks
+      register: _docker_upgrade_counter_after
+      changed_when: false
+
+    - name: Assert counter workload remained functional
+      ansible.builtin.assert:
+        that:
+          - _docker_upgrade_counter_after.stdout | int > _docker_upgrade_before.counter
+
+    - name: Verify HTTP workload is functional
+      ansible.builtin.uri:
+        url: http://127.0.0.1:18080/
+        return_content: true
+      register: _docker_upgrade_http_after
+      failed_when: >-
+        _docker_upgrade_http_after.status != 200 or
+        'docker-upgrade-ok' not in _docker_upgrade_http_after.content

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -1,1 +1,8 @@
 # `docker`
+
+Docker releases are installed into a versioned directory under
+`download_artifact_work_directory` and linked into `/usr/bin`. Updating the
+links and daemon configuration does not restart a running Docker service by
+default. Set `docker_restart_on_update: true` to activate updates immediately;
+otherwise, activate the installed version during a separate service or node
+maintenance operation.

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -18,8 +18,10 @@ docker_version: "{{ docker_versions | last }}"
 docker_archive_checksums:
   amd64:
     24.0.9: 692ecfc28333485d184f628b74c25b2894cee9495a51a5418ba60ef95bf733ca
+    29.7.2: 803d433f226db4776e1768fd319fc6c6e4935a456acf84fcc0080818b854bc8f
   arm64:
     24.0.9: 7e999590330a15469de20ac37051407d222ea73c71c10c05d61666d42c5922d1
+    29.7.2: 43d143448adf2c2787704e7d7704fd6d62d367a54c5edaef0a3f75509cb0938d
 
 docker_download_url: "https://download.docker.com/linux/static/stable/{{ ansible_facts['architecture'] | lower }}/docker-{{ docker_version }}.tgz" # noqa: yaml[line-length]
 

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -27,6 +27,17 @@ docker_download_url: "https://download.docker.com/linux/static/stable/{{ ansible
 
 docker_download_dest: "{{ download_artifact_work_directory }}/docker-{{ docker_version }}.tgz"
 docker_archive_checksum: "{{ docker_archive_checksums[download_artifact_goarch][docker_version] }}"
+docker_binary_install_dir: "{{ download_artifact_work_directory }}/docker-{{ docker_version }}"
+docker_binaries:
+  - docker
+  - docker-init
+  - dockerd
+  - docker-proxy
+
+# Updating the installed binaries and configuration does not require activating
+# them immediately. Service or node restarts can be performed separately as
+# part of a controlled maintenance operation.
+docker_restart_on_update: false
 
 # NOTE(mnaser): This is to accomodate for the uninstallation of the old packages
 #               that shipped with the operating system

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -12,8 +12,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Restart docker
+- name: Reload Docker systemd units
   ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart docker
+  ansible.builtin.service:
     name: docker
     state: restarted
-    daemon_reload: true
+  when: docker_restart_on_update | bool

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,6 +13,7 @@
 # under the License.
 
 - name: Restart docker
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: docker
     state: restarted
+    daemon_reload: true

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -34,6 +34,10 @@ dependencies:
   - role: forget_package
     forget_package_name: "{{ docker_package_name }}"
     when: ansible_facts['pkg_mgr'] == "apt"
+  - role: directory
+    directory_path: "{{ docker_binary_install_dir }}"
+    directory_owner: root
+    directory_mode: "0755"
   - role: download_artifact
     download_artifact_url: "{{ docker_download_url }}"
     download_artifact_dest: "{{ docker_download_dest }}"
@@ -41,7 +45,7 @@ dependencies:
     download_artifact_owner: root
     download_artifact_mode: "0755"
     download_artifact_unarchive: true
-    download_artifact_unarchive_dest: /usr/bin
+    download_artifact_unarchive_dest: "{{ docker_binary_install_dir }}"
     download_artifact_unarchive_include:
       - docker/docker
       - docker/docker-init

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -24,6 +24,13 @@
   until: _install_apparmor is not failed
   when: ansible_facts['os_family'] == "Debian"
 
+- name: Install SELinux packages
+  ansible.builtin.package:
+    state: present
+    name:
+      - container-selinux
+  when: ansible_facts['os_family'] == "RedHat"
+
 - name: Ensure group "docker" exists
   ansible.builtin.group:
     name: docker
@@ -33,9 +40,8 @@
   ansible.builtin.template:
     src: docker.service.j2
     dest: /etc/systemd/system/docker.service
-    mode: "0644"
+    mode: "0o644"
   notify:
-    - Reload systemd
     - Restart docker
 
 - name: Create folders for configuration
@@ -56,16 +62,15 @@
   ansible.builtin.copy:
     src: docker.socket
     dest: /usr/lib/systemd/system/docker.socket
-    mode: "0644"
+    mode: "0o644"
   notify:
-    - Reload systemd
     - Restart docker
 
 - name: Create docker daemon config file
   ansible.builtin.copy:
     content: "{{ _docker_config | combine(docker_config, recursive=True) | to_nice_json }}"  # noqa: yaml[line-length]
     dest: "{{ docker_cfg_file }}"
-    mode: "0644"
+    mode: "0o644"
   notify:
     - Restart docker
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -18,10 +18,10 @@
     name:
       - apparmor
       - apparmor-utils
-  register: _install_apparmor
+  register: docker_install_apparmor
   retries: 5
   delay: 10
-  until: _install_apparmor is not failed
+  until: docker_install_apparmor is not failed
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Install SELinux packages
@@ -29,10 +29,10 @@
     state: present
     name:
       - container-selinux
-  register: _install_selinux
+  register: docker_install_selinux
   retries: 5
   delay: 10
-  until: _install_selinux is not failed
+  until: docker_install_selinux is not failed
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Ensure group "docker" exists
@@ -40,12 +40,23 @@
     name: docker
     state: present
 
+- name: Create links to Docker binaries
+  ansible.builtin.file:
+    src: "{{ docker_binary_install_dir }}/{{ item }}"
+    dest: "/usr/bin/{{ item }}"
+    state: link
+    force: true
+  loop: "{{ docker_binaries }}"
+  notify:
+    - Restart docker
+
 - name: Create systemd service file for docker
   ansible.builtin.template:
     src: docker.service.j2
     dest: /etc/systemd/system/docker.service
     mode: "0o644"
   notify:
+    - Reload Docker systemd units
     - Restart docker
 
 - name: Create folders for configuration
@@ -68,6 +79,7 @@
     dest: /usr/lib/systemd/system/docker.socket
     mode: "0o644"
   notify:
+    - Reload Docker systemd units
     - Restart docker
 
 - name: Create docker daemon config file

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -29,6 +29,10 @@
     state: present
     name:
       - container-selinux
+  register: _install_selinux
+  retries: 5
+  delay: 10
+  until: _install_selinux is not failed
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Ensure group "docker" exists

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
+# Copyright (c) 2026 VEXXHOST, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -14,7 +14,6 @@
 _docker_config:
   exec-root: "{{ docker_state_dir }}"
   data-root: "{{ docker_storage_dir }}"
-  oom-score-adjust: 0
   bridge: none
   default-ulimits:
     nofile:
@@ -23,7 +22,6 @@ _docker_config:
       soft: 1048576
   ip-forward: false
   iptables: false
-  live-restore: true
   log-opts:
     max-file: "5"
     max-size: "50m"

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -22,6 +22,7 @@ _docker_config:
       soft: 1048576
   ip-forward: false
   iptables: false
+  live-restore: true
   log-opts:
     max-file: "5"
     max-size: "50m"


### PR DESCRIPTION
  - Upgrade Docker to the latest `29.7.2` version
  - Remove notify for non existing handler `Reload systemd`
  - Remove obsolete `oom-score-adjust` setting from defaults (non compatible with Docker>26)
  - Remove `live-restore` from defaults

The last one is even harmful to us because after the docker service is restarted, existing rootful containers using docker socket are misleadingly not informed about the new docker.socket (new inode). As a side effect without this setting all docker containers will be restarted but this is responsibility of IaC to track this and make planned changes. 